### PR TITLE
Fix to track only the right hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Hand_Tracking
+# Hand Tracking
+
+This demo uses MediaPipe to track the user's right hand and pose landmarks. It shows a side panel with controls and coordinate information. The tracker will only follow the right hand. If only the left hand is visible, no hand landmarks will be shown.


### PR DESCRIPTION
## Summary
- filter MediaPipe hand detection so only the right hand is tracked
- allow detecting up to two hands to pick the right one
- clean up README

## Testing
- `python -m py_compile Hand_Tracking.py`

------
https://chatgpt.com/codex/tasks/task_e_683f57c9ed7083239483335738807b97