### PR TITLE
Add mirror camera support

### DIFF
--- a/Hand_Tracking.py
+++ b/Hand_Tracking.py
@@ -1,3 +1,4 @@
+import argparse
 import cv2
 import mediapipe as mp
 import numpy as np
@@ -110,6 +111,23 @@ def create_ui_elements(frame, running_state, right_elbow=None, right_wrist=None)
     }
 
 def main():
+    parser = argparse.ArgumentParser(description="Hand and pose tracking demo")
+    parser.add_argument(
+        "--hand",
+        choices=["Right", "Left"],
+        default="Right",
+        help="Which hand to track",
+    )
+    parser.add_argument(
+        "--mirror",
+        action="store_true",
+        help="Set this flag if your camera feed is mirrored",
+    )
+    args = parser.parse_args()
+
+    tracked_hand_label = args.hand
+    mirrored_camera = args.mirror
+
     # Initialize MediaPipe solutions
     mp_hands = mp.solutions.hands
     mp_pose = mp.solutions.pose
@@ -248,8 +266,10 @@ def main():
                 for hand_landmarks, hand_info in zip(hand_results.multi_hand_landmarks,
                                                      hand_results.multi_handedness):
                     label = hand_info.classification[0].label
-                    if label != "Right":
-                        # Skip left hand detections entirely
+                    if mirrored_camera:
+                        label = "Left" if label == "Right" else "Right"
+                    if label != tracked_hand_label:
+                        # Skip detections that are not the desired hand
                         continue
 
                     # Draw landmarks only for the right hand

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Hand Tracking
 
-This demo uses MediaPipe to track the user's right hand and pose landmarks. It shows a side panel with controls and coordinate information. The tracker will only follow the right hand. If only the left hand is visible, no hand landmarks will be shown.
+This demo uses MediaPipe to track a single hand along with pose landmarks. By default the application tracks the right hand. Use the `--hand` flag to select which hand to follow and `--mirror` if your camera feed is mirrored.


### PR DESCRIPTION
## Summary
- add `--hand` and `--mirror` CLI flags to control which hand is tracked
- update README with new usage info

## Testing
- `python -m py_compile Hand_Tracking.py`

------
https://chatgpt.com/codex/tasks/task_e_683f59d722c88323b70c21a97cfefdb5